### PR TITLE
Fixed incorrect use of delete leaving most of array allocated after use.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -26,7 +26,7 @@ int main() {
     cout << endl;
 
     //destroy the array, but remember the pointer is still there and usable
-    delete myIntArray;
+    delete[] myIntArray;
 
     
     /***********************************************
@@ -62,9 +62,9 @@ int main() {
 
     //destroy the 2D array, but remember the pointer is still there and usable
     for (int i = 0; i < ROWS; i++) {
-        delete my2dIntArray[i];
+        delete[] my2dIntArray[i];
     }
-    delete my2dIntArray;
+    delete[] my2dIntArray;
 
 
     /***********************************************

--- a/main.cpp
+++ b/main.cpp
@@ -91,7 +91,7 @@ int main() {
     // dynamically create an array of Data structs
 
     // create a pointer to Data
-    Data *myDataArray;
+    Data *myDataArray = nullptr;
     // allocate the array
     myDataArray = new Data[SIZE];
 
@@ -105,6 +105,7 @@ int main() {
     // EXERCISE: Dynamically create a 2D array of Data structs, a function
     // to fill it with values, and a function to print them all.
     // *****************************************************************
-    
+    delete[] myDataArray;
+    myDataArray = nullptr;
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -12,7 +12,7 @@ int main() {
      ***********************************************/
 
     // make a pointer to an int
-    int *myIntArray;
+    int *myIntArray = nullptr;
     // allocate the array
     myIntArray = new int[SIZE];
     // initialize it with 1,2,3,4,5
@@ -27,14 +27,14 @@ int main() {
 
     //destroy the array, but remember the pointer is still there and usable
     delete[] myIntArray;
+    myIntArray = nullptr;
 
-    
-    /***********************************************
+        /***********************************************
      * create a 2D array of integers dynamically
      ***********************************************/
 
     // make a pointer to a pointer to an int
-    int **my2dIntArray;
+    int **my2dIntArray = nullptr;
     // allocate the rows
     my2dIntArray = new int*[ROWS];
     // allocate the columns
@@ -65,7 +65,7 @@ int main() {
         delete[] my2dIntArray[i];
     }
     delete[] my2dIntArray;
-
+    my2dIntArray = nullptr;
 
     /***********************************************
      * use pointers and dynamic memory with an ADT


### PR DESCRIPTION
Calling delete on 1d and 2d array pointers would only deallocate the first index of that array. Changed to delete[] to deallocate the whole array. This can lead to major problems down the road and is good practice when managing dynamic memory.

Also set nullptrs to deallocated pointers. This prevents trying to dereference an invalid address.

Data array member was also left to the compiler to clean up after execution. Now cleaned up for explicitness.